### PR TITLE
Changed for more reliable hostname resolution

### DIFF
--- a/tasks/hostname.sh
+++ b/tasks/hostname.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-hostname=$(/usr/bin/hostnamectl --transient)
+hostname=$(/usr/bin/hostname -f)
 
 # Output a JSON result for ease of Task usage in Puppet Task Plans
 echo '{ "hostname": "'$hostname'" }'


### PR DESCRIPTION
Using `hostnamectl --transient` doesn't *always* return the FQDN, which is what the plans are usually expecting. `hostname -f` is a more reliable way of doing this.

Fixes #22