### PR TITLE
Added "if" to not run CA sign on empty certname

### DIFF
--- a/plans/unit/install.pp
+++ b/plans/unit/install.pp
@@ -298,10 +298,12 @@ plan pe_xl::unit::install (
   # For now, waiting a short period of time is necessary to avoid a small race.
   ctrl::sleep(15)
 
-  run_command(inline_epp(@(HEREDOC/L)), $master_target)
-    /opt/puppetlabs/bin/puppetserver ca sign --certname \
-      <%= $agent_installer_targets.map |$target| { $target.host }.join(',') -%>
-    | HEREDOC
+  if !empty($agent_installer_targets) {
+    run_command(inline_epp(@(HEREDOC/L)), $master_target)
+      /opt/puppetlabs/bin/puppetserver ca sign --certname \
+        <%= $agent_installer_targets.map |$target| { $target.host }.join(',') -%>
+      | HEREDOC
+  }
 
   run_task('pe_xl::puppet_runonce', $master_target)
   run_task('pe_xl::puppet_runonce', $all_targets - $master_target)


### PR DESCRIPTION
"puppetserver ca --certname <null>".  The inline template is adding a comma
and when it goes to run the next iteration it has no value for
the certname, causing a failure.  This is for a monlithic-master.